### PR TITLE
Fix numpy array types for wrapper compatibility

### DIFF
--- a/cpp_wrappers/compile_wrappers.sh
+++ b/cpp_wrappers/compile_wrappers.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
 # Compile cpp subsampling
-cd cpp_subsampling
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$DIR/cpp_subsampling"
 python3 setup.py build_ext --inplace
-cd ..
+cd "$DIR"
 
 # Compile cpp neighbors
-cd cpp_neighbors
+cd "$DIR/cpp_neighbors"
 python3 setup.py build_ext --inplace
-cd ..
+cd "$DIR"
+

--- a/cpp_wrappers/cpp_neighbors/wrapper.cpp
+++ b/cpp_wrappers/cpp_neighbors/wrapper.cpp
@@ -80,10 +80,10 @@ static PyObject* batch_neighbors(PyObject* self, PyObject* args, PyObject* keywd
 
 
 	// Interpret the input objects as numpy arrays.
-	PyObject* queries_array = PyArray_FROM_OTF(queries_obj, NPY_FLOAT, NPY_IN_ARRAY);
-	PyObject* supports_array = PyArray_FROM_OTF(supports_obj, NPY_FLOAT, NPY_IN_ARRAY);
-	PyObject* q_batches_array = PyArray_FROM_OTF(q_batches_obj, NPY_INT, NPY_IN_ARRAY);
-	PyObject* s_batches_array = PyArray_FROM_OTF(s_batches_obj, NPY_INT, NPY_IN_ARRAY);
+    PyArrayObject* queries_array = (PyArrayObject*)PyArray_FROM_OTF(queries_obj, NPY_FLOAT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject* supports_array = (PyArrayObject*)PyArray_FROM_OTF(supports_obj, NPY_FLOAT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject* q_batches_array = (PyArrayObject*)PyArray_FROM_OTF(q_batches_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject* s_batches_array = (PyArrayObject*)PyArray_FROM_OTF(s_batches_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
 
 	// Verify data was load correctly.
 	if (queries_array == NULL)
@@ -216,15 +216,15 @@ static PyObject* batch_neighbors(PyObject* self, PyObject* args, PyObject* keywd
 	neighbors_dims[1] = max_neighbors;
 
 	// Create output array
-	PyObject* res_obj = PyArray_SimpleNew(2, neighbors_dims, NPY_INT);
-	PyObject* ret = NULL;
+    PyArrayObject* res_obj = (PyArrayObject*)PyArray_SimpleNew(2, neighbors_dims, NPY_INT);
+    PyObject* ret = NULL;
 
 	// Fill output array with values
 	size_t size_in_bytes = Nq * max_neighbors * sizeof(int);
 	memcpy(PyArray_DATA(res_obj), neighbors_indices.data(), size_in_bytes);
 
 	// Merge results
-	ret = Py_BuildValue("N", res_obj);
+    ret = Py_BuildValue("N", (PyObject*)res_obj);
 
 	// Clean up
 	// ********

--- a/cpp_wrappers/cpp_subsampling/wrapper.cpp
+++ b/cpp_wrappers/cpp_subsampling/wrapper.cpp
@@ -102,15 +102,15 @@ static PyObject* batch_subsampling(PyObject* self, PyObject* args, PyObject* key
 	if (classes_obj == NULL)
 		use_classes = false;
 
-	// Interpret the input objects as numpy arrays.
-	PyObject* points_array = PyArray_FROM_OTF(points_obj, NPY_FLOAT, NPY_IN_ARRAY);
-	PyObject* batches_array = PyArray_FROM_OTF(batches_obj, NPY_INT, NPY_IN_ARRAY);
-	PyObject* features_array = NULL;
-	PyObject* classes_array = NULL;
-	if (use_feature)
-		features_array = PyArray_FROM_OTF(features_obj, NPY_FLOAT, NPY_IN_ARRAY);
-	if (use_classes)
-		classes_array = PyArray_FROM_OTF(classes_obj, NPY_INT, NPY_IN_ARRAY);
+        // Interpret the input objects as numpy arrays.
+        PyArrayObject* points_array = (PyArrayObject*)PyArray_FROM_OTF(points_obj, NPY_FLOAT, NPY_ARRAY_IN_ARRAY);
+        PyArrayObject* batches_array = (PyArrayObject*)PyArray_FROM_OTF(batches_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+        PyArrayObject* features_array = NULL;
+        PyArrayObject* classes_array = NULL;
+        if (use_feature)
+                features_array = (PyArrayObject*)PyArray_FROM_OTF(features_obj, NPY_FLOAT, NPY_ARRAY_IN_ARRAY);
+        if (use_classes)
+                classes_array = (PyArrayObject*)PyArray_FROM_OTF(classes_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
 
 	// Verify data was load correctly.
 	if (points_array == NULL)
@@ -285,12 +285,12 @@ static PyObject* batch_subsampling(PyObject* self, PyObject* args, PyObject* key
 	npy_intp* batches_dims = new npy_intp[1];
 	batches_dims[0] = Nb;
 
-	// Create output array
-	PyObject* res_points_obj = PyArray_SimpleNew(2, point_dims, NPY_FLOAT);
-	PyObject* res_batches_obj = PyArray_SimpleNew(1, batches_dims, NPY_INT);
-	PyObject* res_features_obj = NULL;
-	PyObject* res_classes_obj = NULL;
-	PyObject* ret = NULL;
+        // Create output array
+        PyArrayObject* res_points_obj = (PyArrayObject*)PyArray_SimpleNew(2, point_dims, NPY_FLOAT);
+        PyArrayObject* res_batches_obj = (PyArrayObject*)PyArray_SimpleNew(1, batches_dims, NPY_INT);
+        PyArrayObject* res_features_obj = NULL;
+        PyArrayObject* res_classes_obj = NULL;
+        PyObject* ret = NULL;
 
 	// Fill output array with values
 	size_t size_in_bytes = subsampled_points.size() * 3 * sizeof(float);
@@ -300,26 +300,26 @@ static PyObject* batch_subsampling(PyObject* self, PyObject* args, PyObject* key
 	if (use_feature)
 	{
 		size_in_bytes = subsampled_points.size() * fdim * sizeof(float);
-		res_features_obj = PyArray_SimpleNew(2, feature_dims, NPY_FLOAT);
+                res_features_obj = (PyArrayObject*)PyArray_SimpleNew(2, feature_dims, NPY_FLOAT);
 		memcpy(PyArray_DATA(res_features_obj), subsampled_features.data(), size_in_bytes);
 	}
 	if (use_classes)
 	{
 		size_in_bytes = subsampled_points.size() * ldim * sizeof(int);
-		res_classes_obj = PyArray_SimpleNew(2, classes_dims, NPY_INT);
+                res_classes_obj = (PyArrayObject*)PyArray_SimpleNew(2, classes_dims, NPY_INT);
 		memcpy(PyArray_DATA(res_classes_obj), subsampled_classes.data(), size_in_bytes);
 	}
 
 
 	// Merge results
 	if (use_feature && use_classes)
-		ret = Py_BuildValue("NNNN", res_points_obj, res_batches_obj, res_features_obj, res_classes_obj);
+                ret = Py_BuildValue("NNNN", (PyObject*)res_points_obj, (PyObject*)res_batches_obj, (PyObject*)res_features_obj, (PyObject*)res_classes_obj);
 	else if (use_feature)
-		ret = Py_BuildValue("NNN", res_points_obj, res_batches_obj, res_features_obj);
+                ret = Py_BuildValue("NNN", (PyObject*)res_points_obj, (PyObject*)res_batches_obj, (PyObject*)res_features_obj);
 	else if (use_classes)
-		ret = Py_BuildValue("NNN", res_points_obj, res_batches_obj, res_classes_obj);
+                ret = Py_BuildValue("NNN", (PyObject*)res_points_obj, (PyObject*)res_batches_obj, (PyObject*)res_classes_obj);
 	else
-		ret = Py_BuildValue("NN", res_points_obj, res_batches_obj);
+                ret = Py_BuildValue("NN", (PyObject*)res_points_obj, (PyObject*)res_batches_obj);
 
 	// Clean up
 	// ********
@@ -377,13 +377,13 @@ static PyObject* cloud_subsampling(PyObject* self, PyObject* args, PyObject* key
 		use_classes = false;
 
 	// Interpret the input objects as numpy arrays.
-	PyObject* points_array = PyArray_FROM_OTF(points_obj, NPY_FLOAT, NPY_IN_ARRAY);
-	PyObject* features_array = NULL;
-	PyObject* classes_array = NULL;
-	if (use_feature)
-		features_array = PyArray_FROM_OTF(features_obj, NPY_FLOAT, NPY_IN_ARRAY);
-	if (use_classes)
-		classes_array = PyArray_FROM_OTF(classes_obj, NPY_INT, NPY_IN_ARRAY);
+        PyArrayObject* points_array = (PyArrayObject*)PyArray_FROM_OTF(points_obj, NPY_FLOAT, NPY_ARRAY_IN_ARRAY);
+        PyArrayObject* features_array = NULL;
+        PyArrayObject* classes_array = NULL;
+        if (use_feature)
+                features_array = (PyArrayObject*)PyArray_FROM_OTF(features_obj, NPY_FLOAT, NPY_ARRAY_IN_ARRAY);
+        if (use_classes)
+                classes_array = (PyArrayObject*)PyArray_FROM_OTF(classes_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
 
 	// Verify data was load correctly.
 	if (points_array == NULL)
@@ -522,11 +522,11 @@ static PyObject* cloud_subsampling(PyObject* self, PyObject* args, PyObject* key
 	classes_dims[0] = subsampled_points.size();
 	classes_dims[1] = ldim;
 
-	// Create output array
-	PyObject* res_points_obj = PyArray_SimpleNew(2, point_dims, NPY_FLOAT);
-	PyObject* res_features_obj = NULL;
-	PyObject* res_classes_obj = NULL;
-	PyObject* ret = NULL;
+        // Create output array
+        PyArrayObject* res_points_obj = (PyArrayObject*)PyArray_SimpleNew(2, point_dims, NPY_FLOAT);
+        PyArrayObject* res_features_obj = NULL;
+        PyArrayObject* res_classes_obj = NULL;
+        PyObject* ret = NULL;
 
 	// Fill output array with values
 	size_t size_in_bytes = subsampled_points.size() * 3 * sizeof(float);
@@ -534,26 +534,26 @@ static PyObject* cloud_subsampling(PyObject* self, PyObject* args, PyObject* key
 	if (use_feature)
 	{
 		size_in_bytes = subsampled_points.size() * fdim * sizeof(float);
-		res_features_obj = PyArray_SimpleNew(2, feature_dims, NPY_FLOAT);
+                res_features_obj = (PyArrayObject*)PyArray_SimpleNew(2, feature_dims, NPY_FLOAT);
 		memcpy(PyArray_DATA(res_features_obj), subsampled_features.data(), size_in_bytes);
 	}
 	if (use_classes)
 	{
 		size_in_bytes = subsampled_points.size() * ldim * sizeof(int);
-		res_classes_obj = PyArray_SimpleNew(2, classes_dims, NPY_INT);
+                res_classes_obj = (PyArrayObject*)PyArray_SimpleNew(2, classes_dims, NPY_INT);
 		memcpy(PyArray_DATA(res_classes_obj), subsampled_classes.data(), size_in_bytes);
 	}
 
 
 	// Merge results
 	if (use_feature && use_classes)
-		ret = Py_BuildValue("NNN", res_points_obj, res_features_obj, res_classes_obj);
+                ret = Py_BuildValue("NNN", (PyObject*)res_points_obj, (PyObject*)res_features_obj, (PyObject*)res_classes_obj);
 	else if (use_feature)
-		ret = Py_BuildValue("NN", res_points_obj, res_features_obj);
+                ret = Py_BuildValue("NN", (PyObject*)res_points_obj, (PyObject*)res_features_obj);
 	else if (use_classes)
-		ret = Py_BuildValue("NN", res_points_obj, res_classes_obj);
+                ret = Py_BuildValue("NN", (PyObject*)res_points_obj, (PyObject*)res_classes_obj);
 	else
-		ret = Py_BuildValue("N", res_points_obj);
+                ret = Py_BuildValue("N", (PyObject*)res_points_obj);
 
 	// Clean up
 	// ********


### PR DESCRIPTION
## Summary
- use `PyArrayObject*` variables for numpy arrays
- update wrapper compile script to run from any directory
- replace deprecated `NPY_IN_ARRAY` with `NPY_ARRAY_IN_ARRAY`

## Testing
- `bash cpp_wrappers/compile_wrappers.sh`

------
https://chatgpt.com/codex/tasks/task_e_68654a8128d0833089c9af0d89b1e4de